### PR TITLE
Mountain in waterlevel - BugFix

### DIFF
--- a/Assets/Scenes/Water Level.unity
+++ b/Assets/Scenes/Water Level.unity
@@ -2344,6 +2344,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 45001675, guid: 830d171aa99e14d429e30afa71a8a46c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7906761430492007848, guid: 830d171aa99e14d429e30afa71a8a46c, type: 3}
       propertyPath: m_Name
       value: World2(Water)
@@ -2853,6 +2857,25 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5016844766553462225, guid: 3432d9d4319b1c841a44cc82073458ce, type: 3}
   m_PrefabInstance: {fileID: 140320116}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2067386334 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7906761430735931840, guid: 830d171aa99e14d429e30afa71a8a46c, type: 3}
+  m_PrefabInstance: {fileID: 900353626}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &2067386338
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2067386334}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 6c5d0853a8153ed4686e4f2bb0116b8e, type: 3}
 --- !u!114 &2118718854 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3838563776528317729, guid: 3432d9d4319b1c841a44cc82073458ce, type: 3}

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -27,13 +27,13 @@ EditorUserSettings:
       value: 5a5757560101590a5d0c0e24427b5d44434e4c7a7b7a23677f2b4565b7b5353a
       flags: 0
     RecentlyUsedSceneGuid-7:
-      value: 5705515456015a0c5e565972487b5c4412151a2e7f2a7169747f1f36bbe4363a
-      flags: 0
-    RecentlyUsedSceneGuid-8:
       value: 000151525c570c585a5f5c7111740b44154f412b782e73332e2a4e6be0e26568
       flags: 0
-    RecentlyUsedSceneGuid-9:
+    RecentlyUsedSceneGuid-8:
       value: 5b0506025c535f0b5d5c5e7744760b44124f1a72792a74327a7e4a32b1b6613b
+      flags: 0
+    RecentlyUsedSceneGuid-9:
+      value: 5705515456015a0c5e565972487b5c4412151a2e7f2a7169747f1f36bbe4363a
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
Turned off the colliders that were put around it that were blocking the entire level when going around the back and added a mesh collider to the mountain.