### PR TITLE
Upgrade bug that would lock weapons up and not let you switch or reload

### DIFF
--- a/Assets/Scenes/Ice Level.unity
+++ b/Assets/Scenes/Ice Level.unity
@@ -17756,7 +17756,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6272015389978710680, guid: f863cb9ae0c55ad4e9f71a2fae735550, type: 3}
       propertyPath: totalCurrency
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 6272015389978710680, guid: f863cb9ae0c55ad4e9f71a2fae735550, type: 3}
       propertyPath: gunList.Array.size

--- a/Assets/Scripts/Shop/Workbench.cs
+++ b/Assets/Scripts/Shop/Workbench.cs
@@ -156,6 +156,8 @@ public class Workbench : MonoBehaviour
             gameManager.instance.playerScript.UpdateShootDamage();
             gameManager.instance.UpdateUI();
             gameManager.instance.isShopping = false;
+            if (gameManager.instance.playerScript.gunList[gameManager.instance.playerScript.selectedGun].currentAmmo == 0)
+                StartCoroutine(gameManager.instance.playerScript.Reload());
         }
     }
 
@@ -270,6 +272,7 @@ public class Workbench : MonoBehaviour
             {
                 guns[gunToShow].currentMagazines = guns[gunToShow].maxMagazines;
                 guns[gunToShow].currentMaxAmmo = guns[gunToShow].currentMagazines * guns[gunToShow].magCapacity;
+                guns[gunToShow].isOutOfAmmo = false;
                 gameManager.instance.UpdateActiveAmmo();
                 gameManager.instance.UpdateInactiveAmmo();
             }


### PR DESCRIPTION
Fixed the bug that left you unable to swap weapons or reload after upgrading max ammo when gun was empty